### PR TITLE
Dev 117048 gcp log ingestion to include projectid in the lm. resourceid array for resource mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ This filter plugin is provided for mapping the logs coming from GCP pubsub to '_
 * Google Cloud Functions
 * Google Cloud SQL
 * Google Audit Logs
+* Google Cloud Composer
+* Google Cloud Run
 

--- a/fluent-plugin-lm-logs-gcp.gemspec
+++ b/fluent-plugin-lm-logs-gcp.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |spec|
   spec.name                           = "fluent-plugin-lm-logs-gcp"
-  spec.version                        = '1.0.3'
+  spec.version                        = '1.0.4'
   spec.authors                        = ["LogicMonitor"]
   spec.email                          = "rubygems@logicmonitor.com"
   spec.summary                        = "LogicMonitor with GCP logs fluentd filter plugin"

--- a/lib/fluent/plugin/filter_gcplm.rb
+++ b/lib/fluent/plugin/filter_gcplm.rb
@@ -67,9 +67,11 @@ module Fluent::Plugin
       end
 
       if(record.key?("protoPayload") && record.dig('protoPayload', '@type') == "type.googleapis.com/google.cloud.audit.AuditLog")
-        resourceMap = {"system.gcp.projectId" => project_id, "system.cloud.category" => 'GCP/LMAccount'}
+        resourceMap = {"system.cloud.category" => 'GCP/LMAccount'}
       end
 
+
+      resourceMap['system.gcp.projectId'] = project_id if !resourceMap.empty?
       # Creating a new record which is further sent to LM
       filteredRecord['message'] = message
       filteredRecord['_lm.resourceId'] = resourceMap

--- a/test/plugin/test_filter_gcplm_cf.rb
+++ b/test/plugin/test_filter_gcplm_cf.rb
@@ -51,7 +51,8 @@ class FluentGCPLMCFTest < Test::Unit::TestCase
                 expected = [{
                     "_lm.resourceId" => {
                         "system.gcp.resourcename" =>"projects/logicmonitor.com:api-project-650342240768/locations/asia-south1/functions/testfunctionlogsToPubsub",
-                        "system.cloud.category" => 'GCP/CloudFunction'
+                        "system.cloud.category" => 'GCP/CloudFunction',
+                        "system.gcp.projectId" =>"logicmonitor.com:api-project-650342240768"
                         },
                     "message" =>"Function execution took 200 ms, finished with status: 'ok'",
                     "timestamp" => "2021-04-15T06:14:10.997438123Z"

--- a/test/plugin/test_filter_gcplm_cloudcomposer.rb
+++ b/test/plugin/test_filter_gcplm_cloudcomposer.rb
@@ -50,7 +50,8 @@ class FluentGCPLMCloudComposerTest < Test::Unit::TestCase
                 expected = [{
                     "_lm.resourceId" => {
                         "system.gcp.resourcename" => "projects/development-198123/locations/asia-south1/environments/example-environment",
-                        "system.cloud.category" => "GCP/CloudComposer"
+                        "system.cloud.category" => "GCP/CloudComposer",
+                        "system.gcp.projectId" =>"development-198123"
                         },
                     "message" => "[2021-05-11 11:16:19,726] {dag_processing.py:1316} INFO - Failing jobs without heartbeat after 2021-05-11 11:11:19.726821+00:00\n",
                     "timestamp" => "2021-05-11T11:17:12.683674946Z"

--- a/test/plugin/test_filter_gcplm_cloudrun.rb
+++ b/test/plugin/test_filter_gcplm_cloudrun.rb
@@ -63,7 +63,8 @@ class FluentGCPLMCloudRunTest < Test::Unit::TestCase
                 expected = [{
                     "_lm.resourceId" => {
                         "system.gcp.resourcename" => "hello",
-                        "system.cloud.category" => 'GCP/CloudRun'
+                        "system.cloud.category" => 'GCP/CloudRun',
+                        "system.gcp.projectId" =>"development-198123"
                         },
                     "message" => "{\"requestMethod\":\"GET\",\"requestUrl\":\"https:\/\/hello-tkbjruipeq-uc.a.run.app\/\",\"requestSize\":\"345\",\"status\":500,\"userAgent\":\"LogicMonitor SiteMonitor\/1.0\",\"remoteIp\":\"34.223.95.106\",\"serverIp\":\"216.239.36.53\",\"latency\":\"0.004592759s\",\"protocol\":\"HTTP\/1.1\"}",
                     "timestamp" => "2021-05-10T05:57:08.647307Z"
@@ -98,8 +99,9 @@ class FluentGCPLMCloudRunTest < Test::Unit::TestCase
                 expected = [{
                     "_lm.resourceId" => {
                         "system.gcp.resourcename" => "logging-manual",
-                        "system.cloud.category" => 'GCP/CloudRun'
-                        },
+                        "system.cloud.category" => 'GCP/CloudRun',
+                        "system.gcp.projectId" =>"development-198123"
+                    },
                     "message" => "> logging-manual@ start /usr/src/app",
                     "timestamp" => "2021-05-10T05:02:17.921246Z"
                     }]

--- a/test/plugin/test_filter_gcplm_cloudsql.rb
+++ b/test/plugin/test_filter_gcplm_cloudsql.rb
@@ -47,7 +47,8 @@ class FluentGCPLMCloudSqlTest < Test::Unit::TestCase
                 expected = [{
                     "_lm.resourceId" => {
                         "system.gcp.resourceid" =>"development-198123:rwaver-sql-1",
-                        "system.cloud.category" => 'GCP/CloudSQL'
+                        "system.cloud.category" => 'GCP/CloudSQL',
+                        "system.gcp.projectId" =>"development-198123"
                         },
                     "message" =>"2021-04-27T14:34:16.352086Z 0 [ERROR] Could not successfully notify external app of semisync status change before timeout.",
                     "timestamp" => "2021-04-27T14:34:16.352421Z"

--- a/test/plugin/test_filter_gcplm_recordmessage.rb
+++ b/test/plugin/test_filter_gcplm_recordmessage.rb
@@ -46,7 +46,8 @@ class FluentGCPLMMessageTest < Test::Unit::TestCase
 
           expected = [{
               "_lm.resourceId" => {
-                  "system.gcp.resourceid" =>"development-198123:testmysqllogstol"
+                  "system.gcp.resourceid" =>"development-198123:testmysqllogstol",
+                  "system.gcp.projectId" =>"development-198123"
                   },
               "message" =>"Permission monitoring.timeSeries.create denied (or the resource may not exist)",
               "timestamp" => "2021-04-28T10:13:07.252739Z"
@@ -83,7 +84,8 @@ class FluentGCPLMMessageTest < Test::Unit::TestCase
 
           expected=[{
               "_lm.resourceId" => {
-                  "system.gcp.resourceid" =>"7637443554836808513"
+                  "system.gcp.resourceid" =>"7637443554836808513",
+                  "system.gcp.projectId" =>"development-198123"
                   },
               "message" =>"{\"message\":\"startup-script: chmod: changing permissions of '/etc/systemd/system/dbus-org.freedesktop.network1.service': Read-only file system\",\"localTimestamp\":\"2021-04-28T14:32:03.2422Z\"}",
               "timestamp" => "2021-04-28T14:32:03.243408039Z"
@@ -203,7 +205,8 @@ class FluentGCPLMMessageTest < Test::Unit::TestCase
 
             expected = [{
                 "_lm.resourceId" => {
-                    "system.gcp.resourceid" =>"development-198123:testmysqllogstol"
+                    "system.gcp.resourceid" =>"development-198123:testmysqllogstol",
+                    "system.gcp.projectId" =>"development-198123"
                     },
                 "message" =>"Permission monitoring.timeSeries.create denied (or the resource may not exist)",
                 "timestamp" => "2021-04-28T10:13:07.252739Z"

--- a/test/plugin/test_filter_gcplm_vm.rb
+++ b/test/plugin/test_filter_gcplm_vm.rb
@@ -57,8 +57,12 @@ class FluentGCPLMVMTest < Test::Unit::TestCase
         "textPayload" => "BaudRate/Actual (115200/115200) = 100%\r\n",
         "insertId" => "181",
         "resource" => {
-            "type" => "gce_instance"
-            },
+            "type" => "gce_instance",
+            "labels" => {
+                "project_id" => "development-198123",
+                "zone" => "us-central1-a"
+                }
+        },
         "timestamp" => "2021-04-28T13:08:27.808628469Z",
         "labels" => {
             "compute.googleapis.com/resource_name" => "gke-standard-cluster-1-a-default-pool-96c859da-e9e7"
@@ -70,7 +74,8 @@ class FluentGCPLMVMTest < Test::Unit::TestCase
       expected = [{
         "_lm.resourceId" => {
             "system.gcp.resourceid" =>"1437928523886234104",
-            "system.cloud.category" => 'GCP/ComputeEngine'
+            "system.cloud.category" => 'GCP/ComputeEngine',
+            "system.gcp.projectId" =>"development-198123"
             },
         "message" =>"\"PRIORITY\": \"6\",\"_HOSTNAME\": \"gke-k8s-demo-default-pool-8eece21e-z6er\",\"_GID\": \"0\",\"_BOOT_ID\": \"fa612042f606422a80b4c64c2c642eb5\",\"_SYSTEMD_SLICE\": \"system.slice\",\"SYSLOG_IDENTIFIER\": \"kubelet\",\"_CAP_EFFECTIVE\": \"3fffffffff\",\"_STREAM_ID\": \"6aba8f44b68e4718a13999c63d142e28\",\"_CMDLINE\": \"/home/kubernetes/bin/kubelet --v=2 --cloud-provider=gce --experimental-check-node-capabilities-before-mount=true --experimental-mounter-path=/home/kubernetes/containerized_mounter/mounter --cert-dir=/var/lib/kubelet/pki/ --cni-bin-dir=/home/kubernetes/bin --kubeconfig=/var/lib/kubelet/kubeconfig --image-pull-progress-deadline=5m --experimental-kernel-memcg-notification=true --max-pods=110 --non-masquerade-cidr=0.0.0.0/0 --network-plugin=kubenet --node-labels=beta.kubernetes.io/fluentd-ds-ready=true,cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos --volume-plugin-dir=/home/kubernetes/flexvolume --bootstrap-kubeconfig=/var/lib/kubelet/bootstrap-kubeconfig --node-status-max-images=25 --registry-qps=10 --registry-burst=20 --config /home/kubernetes/kubelet-config.yaml --pod-sysctls=net.core.somaxconn=1024,net.ipv4.conf.all.accept_redirects=0,net.ipv4.conf.all.forwarding=1,net.ipv4.conf.all.route_localnet=1,net.ipv4.conf.default.forwarding=1,net.ipv4.ip_forward=1,net.ipv4.tcp_fin_timeout=60,net.ipv4.tcp_keepalive_intvl=75,net.ipv4.tcp_keepalive_probes=9,net.ipv4.tcp_keepalive_time=7200,net.ipv4.tcp_rmem=4096 87380 6291456,net.ipv4.tcp_syn_retries=6,net.ipv4.tcp_tw_reuse=0,net.ipv4.tcp_wmem=4096 16384 4194304,net.ipv4.udp_rmem_min=4096,net.ipv4.udp_wmem_min=4096,net.ipv6.conf.default.accept_ra=0,net.netfilter.nf_conntrack_generic_timeout=600,net.netfilter.nf_conntrack_tcp_timeout_close_wait=3600,net.netfilter.nf_conntrack_tcp_timeout_established=86400\",
                              \"_PID\": \"1243\",\"MESSAGE\": \"I0415 06:18:20.943836    1243 kubelet_getters.go:177] status for pod kube-proxy-gke-k8s-demo-default-pool-8eece21e-z6er updated to {Running [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2021-01-21 17:17:43 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2021-01-21 17:17:44 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 2021-01-21 17:17:44 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2021-01-21 17:17:43 +0000 UTC  }]    10.128.15.198 10.128.15.198 2021-01-21 17:17:43 +0000 UTC [] [{kube-proxy {nil &ContainerStateRunning{StartedAt:2021-01-21 17:17:44 +0000 UTC,} nil} {nil nil nil} true 0 gke.gcr.io/kube-proxy:v1.15.12-gke.6002 docker://sha256:d97a2b9779ce0e53fc2ae82dc68a6ca97c1e8cbe111f99814715b730c28523e7 docker://0a8d009d27318e01ee97899e70b2a9d9de27d62a7baf781574f648a2cb5e9aa1}] Burstable}\"",
@@ -79,7 +84,8 @@ class FluentGCPLMVMTest < Test::Unit::TestCase
         {
         "_lm.resourceId" => {
             "system.gcp.resourcename" =>"gke-standard-cluster-1-a-default-pool-96c859da-e9e7",
-            "system.cloud.category" => 'GCP/ComputeEngine'
+            "system.cloud.category" => 'GCP/ComputeEngine',
+            "system.gcp.projectId" =>"development-198123"
             },
         "message" =>"BaudRate/Actual (115200/115200) = 100%\r\n",
         "timestamp" => "2021-04-28T13:08:27.808628469Z"


### PR DESCRIPTION
Implementation for ticket https://jira.logicmonitor.com/browse/DEV-117048
The basic requirement was that a customer should be able to ingest logs from resources having same names but present in different project. Hence, adding project_id in the resourceId map